### PR TITLE
cleanup runbot build

### DIFF
--- a/project_issue_department/__openerp__.py
+++ b/project_issue_department/__openerp__.py
@@ -34,7 +34,7 @@ Project's defined Department.
         'project_issue',
         'project_department',
     ],
-    'update_xml': [
+    'data': [
         'project_issue_view.xml',
         'security/ir.model.access.csv',
     ],


### PR DESCRIPTION
the presence of update_xml triggers a warning, which prevents a green runbot build
